### PR TITLE
Fix portability of ARM64 neon assembly

### DIFF
--- a/src/m_arm64_neon.S
+++ b/src/m_arm64_neon.S
@@ -14,9 +14,22 @@
     limitations under the License.
 */
 
-.globl	_unmask
+#ifdef __clang__
+# define TYPE(__proc)
+#else
+# define TYPE(__proc) .type __proc, @function
+#endif
+
+#ifdef __MACH__
+# define PROC_NAME(__proc) _ ## __proc
+#else
+# define PROC_NAME(__proc) __proc
+#endif
+
+.global	PROC_NAME(unmask)
+TYPE(unmask)
 .p2align	2
-_unmask:
+PROC_NAME(unmask):
 	.cfi_startproc
 
 	cbz	x2, end_unmask

--- a/src/m_arm64_neon.S
+++ b/src/m_arm64_neon.S
@@ -56,8 +56,8 @@ unmask_32:
 
 unmask_32_loop:                                 
 	ldp	q2, q3, [x9, #-16]
-	eor.16b	v2, v2, v0
-	eor.16b	v3, v3, v1
+	eor	v2.16b, v2.16b, v0.16b
+	eor	v3.16b, v3.16b, v1.16b
 	stp	q2, q3, [x9, #-16]
 	add	x9, x9, #32                     
 	subs	x10, x10, #32                   
@@ -78,7 +78,7 @@ unmask_8:
 
 unmask_8_loop:                               
 	ldr	d1, [x9]
-	eor.8b	v1, v1, v0
+	eor	v1.8b, v1.8b, v0.8b
 	str	d1, [x9], #8
 	adds	x10, x10, #8                    
 	b.ne	unmask_8_loop


### PR DESCRIPTION
The current assembly code assumes that it is being built for Darwin, using Apple extensions to the ARM64 assembly syntax, and using Mach-O symbol names for publicly exported symbols.

With some minor adjustments, the assembly code can be built for any ARM64 host which uses an ELF (Linux, BSD) or Mach-O (Darwin) ABI.

Tested on:
- Wolfi GNU/Linux (with both clang and gcc compilers)
- macOS Mojave (with default Xcode toolchain)

Fixes #2 (both issues).