### PR TITLE
support vectored writes

### DIFF
--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -31,7 +31,7 @@ async fn handle_client(
   let socket = handshake(socket).await?;
 
   let mut ws = WebSocket::after_handshake(socket);
-  ws.set_writev(false);
+  ws.set_writev(true);
   ws.set_auto_close(true);
   ws.set_auto_pong(true);
 


### PR DESCRIPTION
Closes #4 

Enable vectored writes using `WebSocket::set_writev`. 

We can avoid maintaining a write buffer with vectored writes. The current algorithm is optimzied for 2 IoSlices (Also std's write_all_vectored is _unstable_):

1. Try sending header iovec + payload iovec.
2. If header is pending, advance the header iovec and write again.
3. If payload is pending, then `S::write_all` the payload.