### PR TITLE
implement client websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "base64",
  "cc",
  "criterion",
+ "futures",
  "hyper",
  "rand",
  "sha1",
@@ -260,12 +261,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -273,6 +290,40 @@ name = "futures-core"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
@@ -286,10 +337,16 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -768,6 +825,15 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,6 @@ dependencies = [
  "base64",
  "cc",
  "criterion",
- "futures",
  "hyper",
  "rand",
  "sha1",
@@ -261,28 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -290,40 +273,6 @@ name = "futures-core"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
@@ -337,16 +286,10 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -825,15 +768,6 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
-name = "slab"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "examples/echo_server.rs"
 tokio = { version = "1.25.0",  default-features = false, features = ["io-util"] }
 simdutf8 = { version = "0.1.4", optional = true }
 utf-8 = "0.7.5"
+rand = "0.8.4"
 
 [target.'cfg(target_arch = "aarch64")'.build-dependencies]
 cc = { version = "1.0", optional = true }
@@ -25,9 +26,7 @@ simd = ["cc", "simdutf8/aarch64_neon"]
 [dev-dependencies]
 # examples
 tokio = { version = "1.25.0", features = ["full"] }
-rand = "0.8.4"
 base64 = "0.21.0"
-futures = "*"
 sha1 = "0.10.5"
 hyper = { version = "0.14.26", features = ["http1", "server", "client"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,9 @@ simd = ["cc", "simdutf8/aarch64_neon"]
 tokio = { version = "1.25.0", features = ["full"] }
 rand = "0.8.4"
 base64 = "0.21.0"
+futures = "*"
 sha1 = "0.10.5"
-hyper = { version = "0.14.26", features = ["http1", "server"] }
+hyper = { version = "0.14.26", features = ["http1", "server", "client"] }
 
 # bench
 criterion = "0.4.0"

--- a/autobahn/Makefile
+++ b/autobahn/Makefile
@@ -1,9 +1,9 @@
 AUTOBAHN_TESTSUITE_DOCKER := crossbario/autobahn-testsuite:0.8.2@sha256:5d4ba3aa7d6ab2fdbf6606f3f4ecbe4b66f205ce1cbc176d6cdf650157e52242
 
-build:
+build-server:
 	sudo cargo build --release --example echo_server
 
-run: build
+run-server: build-server
 	echo ${PWD}
 	docker run -d  \
 		--name fuzzingserver \
@@ -17,4 +17,21 @@ run: build
 	  wstest -m fuzzingclient -s fuzzingclient.json
 	../target/release/examples/echo_server
 
-.PHONY: build run
+build-client:
+	sudo cargo build --release --example autobahn_client
+
+run-client: build-client
+	echo ${PWD}
+	docker run -d  \
+		--name fuzzingserver \
+		-u `id -u`:`id -g` \
+		-v ${PWD}/fuzzingserver.json:/fuzzingserver.json:ro \
+		-v ${PWD}/reports:/reports \
+		-p 9001:9001 \
+		--rm \
+		$(AUTOBAHN_TESTSUITE_DOCKER) \
+	  wstest -m fuzzingserver -s fuzzingserver.json
+	sleep 5
+	../target/release/examples/autobahn_client
+
+.PHONY: build-server run-server build-client run-client

--- a/autobahn/fuzzingserver.json
+++ b/autobahn/fuzzingserver.json
@@ -1,7 +1,7 @@
 {
 	"url": "ws://127.0.0.1:9001",
 	"outdir": "./reports/client",
-	"cases": ["1.*"],
+	"cases": ["1.*", "2.*", "3.*", "4.*", "5.*", "6.*", "7.*", "9.*", "10.*"],
 	"exclude-cases": [],
 	"exclude-agent-cases": {}
 }

--- a/autobahn/fuzzingserver.json
+++ b/autobahn/fuzzingserver.json
@@ -1,0 +1,7 @@
+{
+	"url": "ws://127.0.0.1:9001",
+	"outdir": "./reports/client",
+	"cases": ["1.*"],
+	"exclude-cases": [],
+	"exclude-agent-cases": {}
+}

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -1,0 +1,113 @@
+// Copyright 2023 Divy Srivastava <dj.srivastava23@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use fastwebsockets::Frame;
+use fastwebsockets::OpCode;
+use fastwebsockets::WebSocket;
+use futures::TryStreamExt;
+use hyper::header::CONNECTION;
+use hyper::upgrade::Upgraded;
+use hyper::Body;
+use std::io::Write;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+use hyper::header::UPGRADE;
+use hyper::Request;
+use hyper::StatusCode;
+
+type Result<T> =
+  std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+async fn connect(path: &str) -> Result<WebSocket<TcpStream>> {
+  let mut stream = TcpStream::connect("localhost:9001").await?;
+
+  let mut req = Vec::new();
+  write!(req, "GET /{} HTTP/1.1\r\n", path).unwrap();
+  write!(req, "Host: localhost:9001\r\n").unwrap();
+  write!(req, "User-Agent: fastwebsockets\r\n").unwrap();
+  write!(req, "Upgrade: websocket\r\n").unwrap();
+  write!(req, "Connection: upgrade\r\n").unwrap();
+  write!(req, "Sec-WebSocket-Key: gn/tcQDBSTmTj39Xf8bBNg==\r\n").unwrap();
+  write!(req, "Sec-WebSocket-Version: 13\r\n").unwrap();
+  write!(req, "\r\n").unwrap();
+
+  stream.write_all(&req).await?;
+
+  // Parse response
+  // Peek and read. Don't read the websocket data
+  let mut buf = [0; 1024];
+  let n = stream.peek(&mut buf).await?;
+  // Find the end of the headers and split the buffer
+  let pos = buf[..n]
+    .windows(4)
+    .position(|window| window == b"\r\n\r\n")
+    .expect("No end of headers");
+
+  stream.read_exact(&mut buf[..pos + 4]).await?;
+
+  Ok(WebSocket::after_handshake(stream))
+}
+
+async fn get_case_count() -> Result<u32> {
+  let mut ws = connect("getCaseCount").await?;
+  let msg = ws.read_frame().await?;
+  ws.write_frame(Frame::close(1000, &[])).await?;
+  Ok(std::str::from_utf8(&msg.payload)?.parse()?)
+}
+
+fn mask(payload: &[u8]) -> (Vec<u8>, [u8; 4]) {
+  let mut mask = [1,2,3,4];
+  let mut masked = Vec::new();
+  for (i, byte) in payload.iter().enumerate() {
+    masked.push(byte ^ mask[i % 4]);
+  }
+  (masked, mask)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+  let count = get_case_count().await?;
+  dbg!(count);
+  for case in 1..=count {
+    let mut ws =
+      connect(&format!("runCase?case={}&agent=fastwebsockets", case)).await?;
+    dbg!(case);
+    loop {
+      let msg = ws.read_frame().await?;
+      
+      match msg.opcode {
+        OpCode::Text | OpCode::Binary => {
+          let (masked, mask) = mask(&msg.payload);
+          ws.write_frame(Frame::new(
+            true,
+            msg.opcode,
+            Some(mask),
+            masked,
+          )).await?;
+        }
+        OpCode::Close => {
+          break;
+        }
+        _ => {}
+      }
+    }
+  }
+
+  let mut ws = connect("updateReports?agent=fastwebsockets").await?;
+  ws.write_frame(Frame::close(1000, &[])).await?;
+
+  Ok(())
+}

--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -16,6 +16,7 @@ use base64;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use fastwebsockets::OpCode;
+use fastwebsockets::Role;
 use fastwebsockets::WebSocket;
 use sha1::Digest;
 use sha1::Sha1;
@@ -34,7 +35,7 @@ use hyper::StatusCode;
 async fn handle_client(
   socket: Upgraded,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-  let mut ws = WebSocket::after_handshake(socket);
+  let mut ws = WebSocket::after_handshake(socket, Role::Server);
   ws.set_writev(true);
   ws.set_auto_close(true);
   ws.set_auto_pong(true);

--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -20,21 +20,17 @@ use fastwebsockets::Role;
 use fastwebsockets::WebSocket;
 use sha1::Digest;
 use sha1::Sha1;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
 use tokio::net::TcpListener;
-
-use hyper::header::HeaderValue;
-use hyper::header::UPGRADE;
-use hyper::server::conn::Http;
-use hyper::service::service_fn;
-use hyper::upgrade::Upgraded;
-use hyper::Body;
-use hyper::Request;
-use hyper::Response;
-use hyper::StatusCode;
+use tokio::net::TcpStream;
 
 async fn handle_client(
-  socket: Upgraded,
+  socket: TcpStream,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let socket = handshake(socket).await?;
+
   let mut ws = WebSocket::after_handshake(socket, Role::Server);
   ws.set_writev(true);
   ws.set_auto_close(true);
@@ -56,44 +52,58 @@ async fn handle_client(
   Ok(())
 }
 
-fn sec_websocket_protocol(key: &[u8]) -> String {
-  let mut sha1 = Sha1::new();
-  sha1.update(key);
-  sha1.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"); // magic string
-  let result = sha1.finalize();
-  STANDARD.encode(&result[..])
+async fn handshake(
+  mut socket: TcpStream,
+) -> Result<TcpStream, Box<dyn std::error::Error + Send + Sync>> {
+  let mut reader = BufReader::new(&mut socket);
+  let mut headers = Vec::new();
+  loop {
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    if line == "\r\n" {
+      break;
+    }
+    headers.push(line);
+  }
+
+  let key = extract_key(headers)?;
+  let response = generate_response(&key);
+  socket.write_all(response.as_bytes()).await?;
+  Ok(socket)
 }
 
-async fn server_upgrade(
-  mut req: Request<Body>,
-) -> Result<Response<String>, Box<dyn std::error::Error + Send + Sync>> {
-  let mut res = Response::new(String::new());
-  if !req.headers().contains_key(UPGRADE) {
-    *res.status_mut() = StatusCode::BAD_REQUEST;
-    return Ok(res);
-  }
-
-  *res.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
-
-  if let Some(key) = req.headers().get("Sec-WebSocket-Protocol") {
-    res.headers_mut().insert(
-      "Sec-WebSocket-Protocol",
-      HeaderValue::from_str(&sec_websocket_protocol(key.as_bytes()))?,
-    );
-  }
-
-  tokio::task::spawn(async move {
-    match hyper::upgrade::on(&mut req).await {
-      Ok(upgraded) => {
-        if let Err(e) = handle_client(upgraded).await {
-          eprintln!("io error: {}", e)
-        };
+fn extract_key(
+  request: Vec<String>,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+  let key = request
+    .iter()
+    .filter_map(|line| {
+      if line.starts_with("Sec-WebSocket-Key:") {
+        Some(line.trim().split(":").nth(1).unwrap().trim())
+      } else {
+        None
       }
-      Err(e) => eprintln!("upgrade error: {}", e),
-    }
-  });
+    })
+    .next()
+    .ok_or("Invalid request: missing Sec-WebSocket-Key header")?
+    .to_owned();
+  Ok(key)
+}
 
-  Ok(res)
+fn generate_response(key: &str) -> String {
+  let mut sha1 = Sha1::new();
+  sha1.update(key.as_bytes());
+  sha1.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"); // magic string
+  let result = sha1.finalize();
+  let encoded = STANDARD.encode(&result[..]);
+  let response = format!(
+    "HTTP/1.1 101 Switching Protocols\r\n\
+                             Upgrade: websocket\r\n\
+                             Connection: Upgrade\r\n\
+                             Sec-WebSocket-Accept: {}\r\n\r\n",
+    encoded
+  );
+  response
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -101,13 +111,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
   let listener = TcpListener::bind("127.0.0.1:8080").await?;
   println!("Server started, listening on {}", "127.0.0.1:8080");
   loop {
-    let (stream, _) = listener.accept().await?;
+    let (socket, _) = listener.accept().await?;
     println!("Client connected");
     tokio::spawn(async move {
-      let conn_fut = Http::new()
-        .serve_connection(stream, service_fn(server_upgrade))
-        .with_upgrades();
-      if let Err(e) = conn_fut.await {
+      if let Err(e) = handle_client(socket).await {
         println!("An error occurred: {:?}", e);
       }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ impl<S> WebSocket<S> {
 
               if !code.is_allowed() {
                 self
-                  .write_frame(Frame::close(1002, &frame.payload[2..]))
+                  .write_frame(Frame::close(1002, &frame.payload[2..], true))
                   .await?;
 
                 return Err("invalid close code".into());
@@ -243,12 +243,12 @@ impl<S> WebSocket<S> {
           };
 
           self
-            .write_frame(Frame::close_raw(frame.payload.clone()))
+            .write_frame(Frame::close_raw(frame.payload.clone(), true))
             .await?;
           break Ok(frame);
         }
         OpCode::Ping if self.auto_pong => {
-          self.write_frame(Frame::pong(frame.payload)).await?;
+          self.write_frame(Frame::pong(frame.payload, true)).await?;
         }
         OpCode::Text => {
           if frame.fin && !frame.is_utf8() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ impl<S> WebSocket<S> {
       stream,
       write_buffer: Vec::with_capacity(2),
       read_buffer: None,
-      vectored: false,
+      vectored: true,
       auto_close: true,
       auto_pong: true,
       max_message_size: 64 << 20,
@@ -214,7 +214,7 @@ impl<S> WebSocket<S> {
   {
     loop {
       let mut frame = self.parse_frame_header().await?;
-      frame.unmask();
+      // frame.unmask();
 
       match frame.opcode {
         OpCode::Close if self.auto_close => {


### PR DESCRIPTION
This commit adds a WebSocket client implementation. Simply pass `Role::Client` when constructing `WebSocket`.

### Usage

Example usage with hyper client:

```rust
use fastwebsockets::WebSocket;
use fastwebsockets::Role;

let upgraded = hyper::upgrade::on(&mut req).await?;
let mut ws = WebSocket::after_handshake(
  upgraded,
  Role::Client,
);
```

Passes all 1-9 Autobahn|TestSuite with fuzzingserver.

### Low level usage

This commit adds `WebSocket::set_auto_apply_mask` method. `auto_apply_mask` enabled by default. 

When disabled, `read_frame` and `write_frame` will _not_ apply mask on the payload as per [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455)

### Other changes

Vectored writes are enabled by default. Use `WebSocket::set_writev()` to control the behaviour.

