### PR TITLE
Add `handshake::client` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ name = "echo_server"
 path = "examples/echo_server.rs"
 required-features = ["upgrade"]
 
+[[example]]
+name = "autobahn_client"
+path = "examples/autobahn_client.rs"
+required-features = ["upgrade"]
+
 [dependencies]
 tokio = { version = "1.25.0",  default-features = false, features = ["io-util"] }
 simdutf8 = { version = "0.1.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ name = "echo_server"
 path = "examples/echo_server.rs"
 required-features = ["upgrade"]
 
-
 [dependencies]
 tokio = { version = "1.25.0",  default-features = false, features = ["io-util"] }
 simdutf8 = { version = "0.1.4", optional = true }

--- a/autobahn/Makefile
+++ b/autobahn/Makefile
@@ -1,7 +1,7 @@
 AUTOBAHN_TESTSUITE_DOCKER := crossbario/autobahn-testsuite:0.8.2@sha256:5d4ba3aa7d6ab2fdbf6606f3f4ecbe4b66f205ce1cbc176d6cdf650157e52242
 
 build-server:
-	sudo cargo build --release --example echo_server
+	sudo cargo build --release --example echo_server --features "upgrade"
 
 run-server: build-server
 	echo ${PWD}
@@ -18,7 +18,7 @@ run-server: build-server
 	../target/release/examples/echo_server
 
 build-client:
-	sudo cargo build --release --example autobahn_client
+	sudo cargo build --release --example autobahn_client --features "upgrade"
 
 run-client: build-client
 	echo ${PWD}

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -34,7 +34,10 @@ async fn connect(path: &str) -> Result<FragmentCollector<Upgraded>> {
     .header("Host", "localhost:9001")
     .header(UPGRADE, "websocket")
     .header(CONNECTION, "upgrade")
-    .header("Sec-WebSocket-Key", "gn/tcQDBSTmTj39Xf8bBNg==")
+    .header(
+      "Sec-WebSocket-Key",
+      fastwebsockets::handshake::generate_key(),
+    )
     .header("Sec-WebSocket-Version", "13")
     .body(Body::empty())?;
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -233,7 +233,7 @@ impl Frame {
     }
 
     // Slighly more optimized than (unstable) write_all_vectored for 2 iovecs.
-    while n < size {
+    while n <= size {
       b[0] = IoSlice::new(&head[n..size]);
       n += stream.write_vectored(&b).await?;
     }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,0 +1,86 @@
+// Copyright 2023 Divy Srivastava <dj.srivastava23@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use hyper::upgrade::Upgraded;
+use hyper::Body;
+use hyper::Request;
+use hyper::StatusCode;
+
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+
+use std::error::Error;
+
+use crate::Role;
+use crate::WebSocket;
+
+pub async fn client<S>(
+  request: Request<Body>,
+  socket: S,
+) -> Result<WebSocket<Upgraded>, Box<dyn Error + Send + Sync>>
+where
+  S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+  let (mut sender, conn) = hyper::client::conn::handshake(socket).await?;
+  tokio::spawn(async move {
+    if let Err(e) = conn.await {
+      eprintln!("Error polling connection: {}", e);
+    }
+  });
+
+  let response = sender.send_request(request).await?;
+  verify(response)?;
+
+  match hyper::upgrade::on(response).await {
+    Ok(upgraded) => Ok(WebSocket::after_handshake(upgraded, Role::Client)),
+    Err(e) => Err(e.into()),
+  }
+}
+
+// https://github.com/snapview/tungstenite-rs/blob/314feea3055a93e585882fb769854a912a7e6dae/src/handshake/client.rs#L189
+fn verify(response: &mut Response) -> Result<(), Box<dyn Error + Send + Sync>> {
+  if response.status() != StatusCode::SWITCHING_PROTOCOLS {
+    return Err("Invalid status code".into());
+  }
+
+  let headers = response.headers();
+
+  if !headers
+    .get("Upgrade")
+    .and_then(|h| h.to_str().ok())
+    .map(|h| h.eq_ignore_ascii_case("websocket"))
+    .unwrap_or(false)
+  {
+    return Err("Invalid Upgrade header".into());
+  }
+
+  if !headers
+    .get("Connection")
+    .and_then(|h| h.to_str().ok())
+    .map(|h| h.eq_ignore_ascii_case("Upgrade"))
+    .unwrap_or(false)
+  {
+    return Err("Invalid Connection header".into());
+  }
+
+  if !headers
+    .get("Sec-WebSocket-Accept")
+    .map(|h| h == &self.accept_key)
+    .unwrap_or(false)
+  {
+    return Err("Invalid Sec-WebSocket-Accept header".into());
+  }
+
+  Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@
 mod close;
 mod fragment;
 mod frame;
+#[cfg(feature = "upgrade")]
+pub mod handshake;
 mod mask;
 #[cfg(feature = "upgrade")]
 pub mod upgrade;


### PR DESCRIPTION
Closes #7 

This commit adds the `handshake` client API behind the `upgrade` feature flag.

```rust
use hyper::Upgraded;
use fastwebsockets::WebSocket;

async fn connect() -> Result<()> {
  let stream = TcpStream::connect("localhost:9001").await?;

  let req = Request::builder()
    .method("GET")
    .uri(format!("http://localhost:9001/", path))
    .header("Host", "localhost:9001")
    .header(UPGRADE, "websocket")
    .header(CONNECTION, "upgrade")
    .header("Sec-WebSocket-Key", "gn/tcQDBSTmTj39Xf8bBNg==")
    .header("Sec-WebSocket-Version", "13")
    .body(Body::empty())?;

  let mut ws: WebSocket<Upgraded> = fastwebsockets::handshake::client(req, stream).await?;
  // ...
}
```